### PR TITLE
Add Perl scripts getlinks.pl and getimgs.pl

### DIFF
--- a/getimgs.pl
+++ b/getimgs.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use LWP::Simple;
+use LWP::UserAgent;  # overcome gzipped pages
+use HTTP::Request;
+use HTML::LinkExtor;
+
+
+my $baseurl = shift;
+
+my $ua = LWP::UserAgent->new();  # using this ua will force non-gzipped pages
+my $req = HTTP::Request->new(GET => $baseurl);
+
+my $parser = HTML::LinkExtor->new(\&pushlinks, $baseurl);
+
+my @imgs = ();
+sub pushlinks {
+	my($tag, %attr) = @_;
+	return if $tag ne 'img';
+	push(@imgs, $attr{src});
+}
+
+my $content = $ua->request($req)->decoded_content;  # decode from UTF-8
+$parser->parse($content);
+
+print join("\n", @imgs), "\n";

--- a/getlinks.pl
+++ b/getlinks.pl
@@ -1,0 +1,28 @@
+#!/usr/bin/perl
+
+use warnings;
+use strict;
+use LWP::Simple;
+use LWP::UserAgent;  # overcome gzipped pages
+use HTTP::Request;
+use HTML::LinkExtor;
+
+
+my $baseurl = shift;
+
+my $ua = LWP::UserAgent->new();  # using this ua will force non-gzipped pages
+my $req = HTTP::Request->new(GET => $baseurl);
+
+my $parser = HTML::LinkExtor->new(\&pushlinks, $baseurl);
+
+my @links = ();
+sub pushlinks {
+	my($tag, %attr) = @_;
+	return if $tag ne 'a';
+	push(@links, $attr{href});
+}
+
+my $content = $ua->request($req)->decoded_content;  # decoded from UTF-8
+$parser->parse($content);
+
+print join("\n", @links), "\n";


### PR DESCRIPTION
Perl was used because finding anchor tag links and image tags can be tricky (e.g. tag names and attributes can be on different lines). Perl also offers slurping (reading the whole file as a line), and a powerful regexp for this task, but moreover and ultimately, it offers the HTML::LinkExtor module to do the link and image URL extraction.
